### PR TITLE
OSQA-823 - Show question list even for non-existing tags & prepopulate tags field for new questions

### DIFF
--- a/forum/forms/qanda.py
+++ b/forum/forms/qanda.py
@@ -71,7 +71,7 @@ class AnswerEditorField(EditorField):
 
 
 class TagNamesField(forms.CharField):
-    def __init__(self, user=None, *args, **kwargs):
+    def __init__(self, user=None, initial='', *args, **kwargs):
         super(TagNamesField, self).__init__(*args, **kwargs)
 
         self.required = True
@@ -82,7 +82,7 @@ class TagNamesField(forms.CharField):
         self.help_text = _('Tags are short keywords, with no spaces within. At least %(min)s and up to %(max)s tags can be used.') % {
             'min': settings.FORM_MIN_NUMBER_OF_TAGS, 'max': settings.FORM_MAX_NUMBER_OF_TAGS    
         }
-        self.initial = ''
+        self.initial = initial
         self.user = user
 
     def clean(self, value):
@@ -175,10 +175,10 @@ class AskForm(forms.Form):
     title  = TitleField()
     text   = QuestionEditorField()
 
-    def __init__(self, data=None, user=None, *args, **kwargs):
+    def __init__(self, data=None, user=None, default_tag='', *args, **kwargs):
         super(AskForm, self).__init__(data, *args, **kwargs)
 
-        self.fields['tags']   = TagNamesField(user)
+        self.fields['tags']   = TagNamesField(user, initial=default_tag)
         
         if int(user.reputation) < settings.CAPTCHA_IF_REP_LESS_THAN and not (user.is_superuser or user.is_staff):
             spam_fields = call_all_handlers('create_anti_spam_field')

--- a/forum/settings/view.py
+++ b/forum/settings/view.py
@@ -57,3 +57,11 @@ LIMIT_RELATED_TAGS = Setting('LIMIT_RELATED_TAGS', 0, VIEW_SET, dict(
 label = _("Limit related tags block"),
 help_text = _("Limit related tags block size in questions list pages. Set to 0 to display all all tags.")))
 
+DISPLAY_EMPTY_LIST_FOR_NONEXISTENT_TAGS = Setting('DISPLAY_EMPTY_LIST_FOR_NONEXISTENT_TAGS', False, VIEW_SET, dict(
+label = _("Display empty question list for nonexistent tags"), required=False,
+help_text = _("Display an empty question list (instead of an error page) for nonexistent tags")))
+
+AUTO_SET_TAG_ON_QUESTION = Setting('AUTO_SET_TAG_ON_QUESTION', False, VIEW_SET, dict(
+label = _("Automatically set tag on questions asked from tag page"), required=False,
+help_text = _("Automatically set the tag on new questions asked from the tag page")))
+

--- a/forum/skins/default/templates/header.html
+++ b/forum/skins/default/templates/header.html
@@ -16,7 +16,7 @@
             {% loopregistry page_top_tabs %}{% spaceless %}
                 <a id="nav_{{ tab_name }}"{% ifequal tab tab_name %} class="on"{% endifequal %} href="{{ tab_url }}" >{{ tab_title }}</a>
             {% endspaceless %}{% endloopregistry %}
-            <a id="nav_ask" href="{% url ask %}" class="special">{% trans "ask a question" %}</a>
+            <a id="nav_ask" href="{% url ask %}{% if settings.AUTO_SET_TAG_ON_QUESTION and tag %}?tag={{ tag }}{% endif %}" class="special">{% trans "ask a question" %}</a>
         </div>
     
         <div id="searchBar">

--- a/forum/views/writers.py
+++ b/forum/views/writers.py
@@ -104,9 +104,12 @@ def ask(request):
                         return HttpResponseRedirect(reverse('auth_signin'))
         elif "go" in request.POST:
             form = AskForm({'title': request.POST['q']}, user=request.user)
-            
+    
+    default_tag = ''
+    if settings.AUTO_SET_TAG_ON_QUESTION and 'tag' in request.GET:
+      default_tag = request.GET['tag']
     if not form:
-        form = AskForm(user=request.user)
+        form = AskForm(user=request.user, default_tag=default_tag)
 
     return render_to_response('ask.html', {
         'form' : form,


### PR DESCRIPTION
Add two new features: 
- show (empty) question list even for non-existing tags (with a 418 return code to prevent indexing them) 
- when the "ask question" link is clicked from a tag page the new question is prepopulated with the given tag 

These features are useful when the OSQA instance is linked from an other site with some automatically generated tags (like "chapter1", "chapter2", ...).
