### PR TITLE
Small rmpyc improvement - make it safe for paths containing spaces

### DIFF
--- a/rmpyc
+++ b/rmpyc
@@ -1,1 +1,3 @@
-rm `find . -name '*.pyc'`
+#!/bin/sh
+find . -name '*.pyc' -print0 | xargs --no-run-if-empty --null --max-chars=4096 rm
+


### PR DESCRIPTION
This is a small improvement to the rmpyc script:
- make it executable
- make it work for paths containing spaces
- make it work on platforms where the command line length is limited (windows +cygwin)
