### PR TITLE
Add support for tag format filtering and auto-tagging questions asked from the tag page

### DIFF
--- a/forum/settings/form.py
+++ b/forum/settings/form.py
@@ -1,5 +1,5 @@
-import os.path
 from base import Setting, SettingSet
+from django.forms.widgets import Textarea
 from django.utils.translation import ugettext_lazy as _
 
 FORUM_SET = SettingSet('form', _('Form settings'), _("General settings for the OSQA forms."), 10)
@@ -14,6 +14,21 @@ label = _("Limit tag creation"),
 help_text = _("Limit tag creation to super users, staff or users with a minimum reputation."),
 required=False))
 
+ENFORCE_TAG_FORMAT_FLAG = Setting('ENFORCE_TAG_FORMAT_FLAG', False, FORUM_SET, dict(
+label = _("Enforce tag format"),
+help_text = _("Should question's tags be checked against a regular expression"),
+required=False))
+
+ENFORCE_TAG_FORMAT_RX = Setting('ENFORCE_TAG_FORMAT_RX', '', FORUM_SET, dict(
+label = _("Enforce tag format RX"),
+help_text = _("Regular eXpression which must match at least one tag on the question"),
+required=False))
+
+ENFORCE_TAG_FORMAT_ERROR_MESSAGE = Setting('ENFORCE_TAG_FORMAT_ERROR_MESSAGE', '', FORUM_SET, dict(
+label = _("Enforce tag format error message"),
+help_text = _("Error message to show if the tags from a question fail to meet the above regular expression (can contain HTML)"),
+widget=Textarea(attrs={'rows': '10'}),
+required=False)) 
 
 """ settings for questions """
 FORM_MIN_QUESTION_TITLE = Setting('FORM_MIN_QUESTION_TITLE', 10, FORUM_SET, dict(

--- a/forum/settings/view.py
+++ b/forum/settings/view.py
@@ -57,3 +57,7 @@ LIMIT_RELATED_TAGS = Setting('LIMIT_RELATED_TAGS', 0, VIEW_SET, dict(
 label = _("Limit related tags block"),
 help_text = _("Limit related tags block size in questions list pages. Set to 0 to display all all tags.")))
 
+AUTO_SET_TAG_ON_QUESTION = Setting('AUTO_SET_TAG_ON_QUESTION', False, VIEW_SET, dict(
+label = _("Automatically set tag on questions asked from tag page"), required=False,
+help_text = _("Automatically set the tag on new questions asked from the tag page")))
+

--- a/forum/skins/default/templates/header.html
+++ b/forum/skins/default/templates/header.html
@@ -42,7 +42,7 @@
             </form>
         </div>
         <div id="nav" class="right">
-            <a id="nav_ask" href="{% url ask %}" class="special">{% trans "ask a question" %}</a>
+            <a id="nav_ask" href="{% url ask %}{% if settings.AUTO_SET_TAG_ON_QUESTION and tag %}?tag={{ tag }}{% endif %}" class="special">{% trans "ask a question" %}</a>
         </div>
     </div>
 </div>

--- a/forum/skins/default/templates/pagedown_editor.html
+++ b/forum/skins/default/templates/pagedown_editor.html
@@ -1,7 +1,7 @@
 {% load i18n extra_tags extra_filters %}
                 <div class="wmd-panel">
                     <div id="wmd-button-bar"></div>
-                    {{ form.text }}
+                    {{ form.text }} {{ form.text.errors }}
                 </div>
                 <div id="wmd-preview" class="wmd-panel wmd-preview"></div>
 

--- a/forum/views/writers.py
+++ b/forum/views/writers.py
@@ -105,8 +105,11 @@ def ask(request):
         elif "go" in request.POST:
             form = AskForm({'title': request.POST['q']}, user=request.user)
             
+    default_tag = ''
+    if settings.AUTO_SET_TAG_ON_QUESTION and 'tag' in request.GET:
+        default_tag = request.GET['tag']
     if not form:
-        form = AskForm(user=request.user)
+        form = AskForm(user=request.user, default_tag=default_tag)
 
     return render_response('ask.html', {
         'form' : form,


### PR DESCRIPTION
This commit adds support for tag filtering (ie. tags are only valid if they satisfy a given regex). It also repairs a small bug with the editor (some error messages weren't displayed) and adds an option to auto-tag questions which are asked from the tag page.
