### PR TITLE
Add a try-catch block around os.linesep 

### DIFF
--- a/forum/markdownext/mdx_settingsparser.py
+++ b/forum/markdownext/mdx_settingsparser.py
@@ -1,4 +1,8 @@
-from os import linesep
+try:
+    from os import linesep
+except ImportError:
+    linesep = "\n"
+
 from csv import reader, QUOTE_NONE
 import markdown
 from markdown import Extension


### PR DESCRIPTION
since Google App Engine doesn't support it [1]. With this OSQA is mostly ready to run on Google App Engine + CloudSQL.

[1] https://groups.google.com/forum/?fromgroups#!topic/google-appengine-python/Kewpfj_0-r8
