### PR TITLE
Added settings import/export command to management script

### DIFF
--- a/forum/management/commands/dump_settings.py
+++ b/forum/management/commands/dump_settings.py
@@ -1,0 +1,27 @@
+from pprint import pformat
+from django.core.management.base import NoArgsCommand
+from forum import settings
+from forum.settings import BaseSetting
+
+class Command(NoArgsCommand):
+    def handle_noargs(self, **options):
+        last_value_default = None
+        for k in dir(settings):
+            attr = getattr(settings, k)
+            if not isinstance(attr, BaseSetting):
+                continue
+            if attr.value == attr.default:
+                if not(last_value_default is None) and last_value_default == False:
+                    print
+                last_value_default = True
+                print "# %s has default value" % k
+                continue
+
+            print
+            last_value_default = False
+            if attr.field_context:
+                if attr.field_context.get('label', None):
+                    print "'''%s'''" % unicode(attr.field_context.get('label'))
+                if attr.field_context.get('help_text', None):
+                    print "'''%s'''" % unicode(attr.field_context.get('help_text'))
+            print "settings.%s = %s" % (k, pformat(attr.value))

--- a/forum/management/commands/update_settings.py
+++ b/forum/management/commands/update_settings.py
@@ -1,0 +1,21 @@
+from django.core.management.base import NoArgsCommand
+from forum import settings as forum_settings
+from settings_osqa import SETTINGS
+
+class Command(NoArgsCommand):
+    def handle_noargs(self, **options):
+        for k, v in SETTINGS.dict.items():
+            try:
+                attr = getattr(forum_settings, k)
+            except AttributeError:
+                print "!!! Attribute %s not found, couldn't set it to %s" % (k, v)
+                continue
+            if attr.value == v:
+                print "# Skipping %s, already has the correct value" % k
+                continue
+            if attr.value != attr.default:
+                print ("!!! Attribute %s has a different value (%s) than its default (%s). " \
+                    + "Won't change it to %s") % (k, attr.value, attr.default, v)
+                continue
+            attr.set_value(v)
+            print "Updated %s" % k


### PR DESCRIPTION
This adds two commands to manage.py: dump_settings and update_settings. These can be useful if you're running a network of sites and want to keep some kind of similarity between the setting set on each.

Usage:

```
python manage.py dump_settings > settings_osqa.py
```

In settings_osqa.py replace ^settings. with SETTINGS. and add:

```
class SettingsHolder:
    dict = {}
    def __setattr__(self, name, value):
        self.dict[name] = value

SETTINGS = SettingsHolder()
```

You can even add more custom code like the following (to make the installation relocable):

```
import os.path
file_path = os.path.dirname(os.path.abspath(__file__))
SETTINGS.UPFILES_FOLDER = os.path.join(file_path, 'forum', 'upfiles', '')
```

Then:

```
python manage.py load_settings
```

Only settings which are set to their default values are updated. This is a precaution to avoid overwriting customized settings.
