### PR TITLE
Setting for static file cache-busting

### DIFF
--- a/forum/templatetags/extra_tags.py
+++ b/forum/templatetags/extra_tags.py
@@ -199,6 +199,8 @@ def media(url):
         url_prefix = re.sub("/+", "/", url_prefix)
 
         url = url_prefix + url
+        if hasattr(djsettings, 'MEDIA_SUFFIX'):
+          url = url + '?' + djsettings.MEDIA_SUFFIX
         return url
 
 @register.simple_tag


### PR DESCRIPTION
Adds a possible setting - to be set from settings_local.py - MEDIA_SUFFIX, which - if present - is appended to the static files included trough the media tag. For example if MEDIA_SUFFIX is 10 then the included file has the URL style.css?10. This is useful when the skin has changed and you would like to bust the cache of the clients so that the site is properly displayed.
