### PR TITLE
Add some more options to restrict user's actions

### DIFF
--- a/forum/modules/ui_objects.py
+++ b/forum/modules/ui_objects.py
@@ -45,6 +45,7 @@ Visibility.STAFF = Visibility('staff')
 Visibility.SUPERUSER = Visibility('superuser')
 Visibility.OWNER = Visibility('owner')
 Visibility.REPUTED = lambda r: Visibility(r)
+Visibility.NOBODY = Visibility('public', negated=True)
 
 
 class Url(object):

--- a/forum/registry.py
+++ b/forum/registry.py
@@ -9,7 +9,6 @@ from forum.templatetags.extra_tags import get_score_badge
 from forum.utils.html import cleanup_urls
 from forum import settings
 
-
 try:
     from django.template import get_templatetags_modules
     modules_template_tags = get_modules_script('templatetags')
@@ -77,7 +76,8 @@ ui.register(ui.USER_MENU,
                 url=lambda u, c: reverse('user_authsettings', kwargs={'id': c['user'].id}),
                 span_attrs={'class': 'user-auth'},
                 weight=100,
-                name='AUTH_SETTINGS'
+                name='AUTH_SETTINGS',
+                visibility=ui.Visibility.AUTHENTICATED if settings.USERS_CAN_CHANGE_AUTH_SETTINGS else ui.Visibility.NOBODY,
             ),
             ui.UserMenuItem(
                 label=_("email notification settings"),

--- a/forum/settings/users.py
+++ b/forum/settings/users.py
@@ -121,3 +121,17 @@ widget=RadioSelect,
 choices=GRAVATAR_DEFAULT_CHOICES,
 required=False))
 
+USERS_CAN_GIVEAWAY_KARMA = Setting('USERS_CAN_GIVEAWAY_KARMA', True, USERS_SET, dict(
+label = _("Enable authenticated users to give away karma"),
+help_text = _("Superuser / staff can give karma regardless of this setting"),
+required=False))
+
+USERS_CAN_OPEN_CLOSE_QUESTIONS = Setting('USERS_CAN_OPEN_CLOSE_QUESTIONS', True, USERS_SET, dict(
+label = _("Enable authenticated users open/close questions"),
+help_text = _("Superuser / staff can open/close questions regardless of this setting. Reputation limit is also taken into account."),
+required=False))
+
+USERS_CAN_CHANGE_AUTH_SETTINGS = Setting('USERS_CAN_CHANGE_AUTH_SETTINGS', True, USERS_SET, dict(
+label = _("Enable users to change auth settings"),
+help_text = _("Enable users to access authentication settings (requires server restart to fully take effect)"),
+required=False))

--- a/forum/skins/default/templates/users/info.html
+++ b/forum/skins/default/templates/users/info.html
@@ -50,11 +50,13 @@
                         </h3>
                     </th>
                 </tr>
-                {% if view_user.real_name %}
-                <tr>
-                    <td>{% trans "real name" %}</td>
-                    <td><b>{{view_user.real_name}}</b></td>
-                </tr>
+                {% if can_view_private %}
+	                {% if view_user.real_name %}
+	                <tr>
+	                    <td>{% trans "real name" %}</td>
+	                    <td><b>{{view_user.real_name}}</b></td>
+	                </tr>
+	                {% endif %}
                 {% endif %}
                 <tr>
                     <td>{% trans "member for" %}</td>

--- a/forum/templatetags/node_tags.py
+++ b/forum/templatetags/node_tags.py
@@ -104,8 +104,9 @@ def post_controls(post, user):
         controls.append(post_control(_('permanent link'), reverse('answer_permanent_link', kwargs={'id' : post.id,}),
                                      title=_("answer permanent link"), command=True, withprompt=True, copy=True))
 
-        # Users should be able to award points for an answer. Users cannot award their own answers
-        if user != post.author and user.is_authenticated():
+        give_karma_enabled = user.is_superuser or user.is_staff or \
+            (settings.USERS_CAN_GIVEAWAY_KARMA and user != post.author and user.is_authenticated())
+        if give_karma_enabled:
             controls.append(post_control(_("award points"), reverse('award_points', kwargs={'user_id' : post.author.id,
                                          'answer_id' : post.id}), title=_("award points to %s") % smart_unicode(post.author.username),
                                          command=True, withprompt=True))
@@ -120,11 +121,11 @@ def post_controls(post, user):
                 controls.append(post_control(_('retag'), edit_url))
         except:
             pass
-
         if post_type == 'question':
-            if post.nis.closed and user.can_reopen_question(post):
+            open_close_enabled = user.is_superuser or user.is_staff or settings.USERS_CAN_OPEN_CLOSE_QUESTIONS
+            if open_close_enabled and post.nis.closed and user.can_reopen_question(post):
                 controls.append(post_control(_('reopen'), reverse('reopen', kwargs={'id': post.id}), command=True))
-            elif not post.nis.closed and user.can_close_question(post):
+            elif open_close_enabled and not post.nis.closed and user.can_close_question(post):
                 controls.append(post_control(_('close'), reverse('close', kwargs={'id': post.id}), command=True, withprompt=True))
 
         if user.can_flag_offensive(post):

--- a/forum/views/auth.py
+++ b/forum/views/auth.py
@@ -317,6 +317,8 @@ def auth_settings(request, id):
 
     if not (request.user.is_superuser or request.user == user_):
         return HttpResponseUnauthorized(request)
+    if not settings.USERS_CAN_CHANGE_AUTH_SETTINGS:
+        return HttpResponseUnauthorized(request)
 
     auth_keys = user_.auth_keys.all()
 


### PR DESCRIPTION
The particular options being:
- USERS_CAN_GIVEAWAY_KARMA
- USERS_CAN_OPEN_CLOSE_QUESTIONS
- USERS_CAN_CHANGE_AUTH_SETTINGS

In some cases these options can prevent users from being distracted by the "gamification" aspect of the site.
