### PR TITLE
Add setting to disable welcome email sending

### DIFF
--- a/forum/actions/user.py
+++ b/forum/actions/user.py
@@ -13,6 +13,8 @@ class UserJoinsAction(ActionProxy):
         self.repute(self.user, int(settings.INITIAL_REP))
 
     def process_action(self):
+        if not settings.SEND_WELCOME_EMAILS:
+            return
         hash = ValidationHash.objects.create_new(self.user, 'email', [self.user.email])
         send_template_email([self.user], "auth/welcome_email.html", {'validation_code': hash})
 

--- a/forum/settings/email.py
+++ b/forum/settings/email.py
@@ -83,4 +83,9 @@ label = _("Send digest only to validated users"),
 help_text = _("If checked the daily digest won't be sent to users that haven't validated their emails."),
 required=False))
 
+SEND_WELCOME_EMAILS = Setting('SEND_WELCOME_EMAILS', True, EMAIL_SET, dict(
+label = _("Send welcome emails"),
+help_text = _("If checked a welcome email will be sent to new users joining the community."),
+required=False))
+
 EMAIL_DIGEST_FLAG = Setting('EMAIL_DIGEST_FLAG', None)


### PR DESCRIPTION
As per title: add setting to disable welcome email sending. This can be useful when closely integrated with a site and the site already sent out a welcome email.
